### PR TITLE
Configurable addon

### DIFF
--- a/bin/addon.js
+++ b/bin/addon.js
@@ -2,6 +2,6 @@
 
 const localAddon = require('..')
 
-localAddon.addon.runHTTPWithOptions({ port: process.env.PORT || 1222 })
+localAddon.addon().runHTTPWithOptions({ port: process.env.PORT || 1222 })
 
 localAddon.startIndexing('./localFiles')

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ let engineUrl = 'http://127.0.0.1:11470'
 
 // Internal modules
 const manifest = require('./lib/manifest')
+const manifestNoCatalogs = require('./lib/manifestNoCatalogs')
 const catalogHandler = require('./lib/catalogHandler')
 const metaHandler = require('./lib/metaHandler')
 const streamHandler = require('./lib/streamHandler')
@@ -26,19 +27,22 @@ const storage = new Storage({
 const metaStorage = new Storage()
 
 // Define the addon
-const addon = new addonSDK(manifest)
+function addon(options) {
+	const addonBuilder = new addonSDK(options.disableCatalogSupport ? manifestNoCatalogs : manifest)
 
-addon.defineCatalogHandler(function(args, cb) {
-	catalogHandler(storage, metaStorage, args, cb)
-})
+	addonBuilder.defineCatalogHandler(function(args, cb) {
+		catalogHandler(storage, metaStorage, args, cb)
+	})
 
-addon.defineMetaHandler(function(args, cb) {
-	metaHandler(storage, metaStorage, engineUrl, args, cb)
-})
+	addonBuilder.defineMetaHandler(function(args, cb) {
+		metaHandler(storage, metaStorage, engineUrl, args, cb)
+	})
 
-addon.defineStreamHandler(function(args, cb) {
-	streamHandler(storage, args, cb)
-})
+	addonBuilder.defineStreamHandler(function(args, cb) {
+		streamHandler(storage, args, cb)
+	})
+	return addonBuilder;
+}
 
 // Exported methods
 function setEngineUrl(url) {

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ const metaStorage = new Storage()
 
 // Define the addon
 function addon(options) {
+	options = options || {}
 	const addonBuilder = new addonSDK(options.disableCatalogSupport ? manifestNoCatalogs : manifest)
 
 	addonBuilder.defineCatalogHandler(function(args, cb) {

--- a/lib/manifestNoCatalogs.js
+++ b/lib/manifestNoCatalogs.js
@@ -18,3 +18,4 @@ module.exports = {
 
 	catalogs: []
 }
+

--- a/lib/manifestNoCatalogs.js
+++ b/lib/manifestNoCatalogs.js
@@ -1,21 +1,6 @@
-const consts = require('./consts')
-
-const pkg = require('../package')
-
-module.exports = {
-	id: 'org.stremio.local',
-	version: pkg.version,
-	description: pkg.description,
-
-	name: 'Local Files (without catalog support)',
-
-	// Properties that determine when Stremio picks this add-on
-	resources: [
-		{ name: 'meta', types: ['other'], idPrefixes: [consts.PREFIX_LOCAL, consts.PREFIX_BT] },
-		{ name: 'stream', types: ['movie', 'series'], idPrefixes: [consts.PREFIX_IMDB] },
-	],
-	types: ['movie', 'series', 'other'],
-
-	catalogs: []
-}
-
+const manifest = require('./manifest')
+const manifestNoCatalogs = Object.assign({}, manifest)
+manifestNoCatalogs.name += ' (without catalog support)'
+manifestNoCatalogs.catalogs = []
+manifestNoCatalogs.resources = manifest.resources.filter(resource => (resource.name != 'catalog' && resource != 'catalog'))
+module.exports = manifestNoCatalogs

--- a/lib/manifestNoCatalogs.js
+++ b/lib/manifestNoCatalogs.js
@@ -1,0 +1,20 @@
+const consts = require('./consts')
+
+const pkg = require('../package')
+
+module.exports = {
+	id: 'org.stremio.local',
+	version: pkg.version,
+	description: pkg.description,
+
+	name: 'Local Files (without catalog support)',
+
+	// Properties that determine when Stremio picks this add-on
+	resources: [
+		{ name: 'meta', types: ['other'], idPrefixes: [consts.PREFIX_LOCAL, consts.PREFIX_BT] },
+		{ name: 'stream', types: ['movie', 'series'], idPrefixes: [consts.PREFIX_IMDB] },
+	],
+	types: ['movie', 'series', 'other'],
+
+	catalogs: []
+}


### PR DESCRIPTION
The addon is now function instead of instance of addonBuilder and accepts a configuration object. There is one configuration option - `disableCatalogSupport` - loads a different manifest without catalog resource.